### PR TITLE
fix max borrow calculation

### DIFF
--- a/contracts/sources/decimal.move
+++ b/contracts/sources/decimal.move
@@ -2,6 +2,7 @@
 module suilend::decimal {
     // 1e18
     const WAD: u256 = 1000000000000000000;
+    const U64_MAX: u256 = 18446744073709551615;
 
     struct Decimal has copy, store, drop {
         value: u256
@@ -92,6 +93,14 @@ module suilend::decimal {
         ((a.value / WAD) as u64)
     }
 
+    public fun saturating_floor(a: Decimal): u64 {
+        if (a.value > U64_MAX * WAD) {
+            (U64_MAX as u64)
+        } else {
+            floor(a)
+        }
+    }
+
     public fun ceil(a: Decimal): u64 {
         (((a.value + WAD - 1) / WAD) as u64)
     }
@@ -135,7 +144,7 @@ module suilend::decimal {
 
 #[test_only]
 module suilend::decimal_tests {
-    use suilend::decimal::{add, sub, mul, div, floor, ceil, pow, lt, gt, le, ge, from, from_percent, saturating_sub};
+    use suilend::decimal::{add, sub, mul, div, floor, ceil, pow, lt, gt, le, ge, from, from_percent, saturating_sub, saturating_floor};
 
     #[test]
     fun test_basic() {
@@ -154,6 +163,8 @@ module suilend::decimal_tests {
         assert!(ge(b, a), 0);
         assert!(saturating_sub(a, b) == from(0), 0);
         assert!(saturating_sub(b, a) == from(1), 0);
+        assert!(saturating_floor(from(18446744073709551615)) == 18446744073709551615, 0);
+        assert!(saturating_floor(add(from(18446744073709551615), from(1))) == 18446744073709551615, 0);
     }
 
     #[test]

--- a/contracts/sources/lending_market.move
+++ b/contracts/sources/lending_market.move
@@ -4,7 +4,7 @@ module suilend::lending_market {
     use suilend::rate_limiter::{Self, RateLimiter, RateLimiterConfig};
     use std::ascii::{Self};
     use sui::event::{Self};
-    use suilend::decimal::{Self, Decimal, mul, ceil, div, add, floor, gt, min};
+    use suilend::decimal::{Self, Decimal, mul, ceil, div, add, floor, gt, min, saturating_floor};
     use sui::object_table::{Self, ObjectTable};
     use sui::bag::{Self, Bag};
     use sui::clock::{Self, Clock};
@@ -680,7 +680,7 @@ module suilend::lending_market {
             clock::timestamp_ms(clock) / 1000
         );
 
-        let rate_limiter_max_borrow_amount = floor(reserve::usd_to_token_amount_lower_bound(
+        let rate_limiter_max_borrow_amount = saturating_floor(reserve::usd_to_token_amount_lower_bound(
             reserve, 
             min(remaining_outflow_usd, decimal::from(1_000_000_000))
         ));


### PR DESCRIPTION
Previously, calculation would overflow when dealing with really small prices (eg $FUD).