### PR TITLE
Configurable Fee receivers

### DIFF
--- a/contracts/suilend/sources/lending_market.move
+++ b/contracts/suilend/sources/lending_market.move
@@ -23,6 +23,7 @@ module suilend::lending_market {
     use suilend::liquidity_mining::{Self};
     use sui::package;
     use sui::sui::SUI;
+    use sui::dynamic_field::{Self};
 
     // === Errors ===
     const EIncorrectVersion: u64 = 1;
@@ -32,14 +33,11 @@ module suilend::lending_market {
     const ERewardPeriodNotOver: u64 = 5;
     const ECannotClaimReward: u64 = 6;
     const EInvalidObligationId: u64 = 7;
+    const EInvalidFeeReceivers: u64 = 8;
 
     // === Constants ===
     const CURRENT_VERSION: u64 = 6;
     const U64_MAX: u64 = 18_446_744_073_709_551_615;
-
-    const FEE_RECEIVER_DAO: address = @0xd52680ae4a2fc9920cd9b102203ea4ee5334fc36bdac0ebd111fdc8f42069129;
-    const FEE_RECEIVER_LABS: address = @0x7d68adb758c18d0f1e6cbbfe07c4c12bce92de37ce61b27b51245a568381b83e;
-    const DAO_FEE_TAKE_RATE_PCT: u64 = 70;
 
     // === One time Witness ===
     public struct LENDING_MARKET has drop {}
@@ -58,7 +56,7 @@ module suilend::lending_market {
 
         // window duration is in seconds
         rate_limiter: RateLimiter,
-        fee_receiver: address,
+        fee_receiver: address, // deprecated
 
         /// unused
         bad_debt_usd: Decimal,
@@ -74,6 +72,15 @@ module suilend::lending_market {
     public struct ObligationOwnerCap<phantom P> has key, store {
         id: UID,
         obligation_id: ID
+    }
+
+    // === Dynamic Fields ===
+    public struct FeeReceiversKey has copy, drop, store { }
+
+    public struct FeeReceivers has store {
+        receivers: vector<address>,
+        weights: vector<u64>,
+        total_weight: u64,
     }
 
     // cTokens redemptions and borrows are rate limited to mitigate exploits. however, 
@@ -172,7 +179,7 @@ module suilend::lending_market {
         LendingMarketOwnerCap<P>, 
         LendingMarket<P>
     ) {
-        let lending_market = LendingMarket<P> {
+        let mut lending_market = LendingMarket<P> {
             id: object::new(ctx),
             version: CURRENT_VERSION,
             reserves: vector::empty(),
@@ -182,11 +189,18 @@ module suilend::lending_market {
             bad_debt_usd: decimal::from(0),
             bad_debt_limit_usd: decimal::from(0),
         };
-        
+
         let owner_cap = LendingMarketOwnerCap<P> { 
             id: object::new(ctx), 
             lending_market_id: object::id(&lending_market) 
         };
+
+        set_fee_receivers(
+            &owner_cap,
+            &mut lending_market, 
+            vector[tx_context::sender(ctx)], 
+            vector[100]
+        );
 
         (owner_cap, lending_market)
     }
@@ -693,8 +707,8 @@ module suilend::lending_market {
             );
         };
 
+        let deposit_reserve = vector::borrow_mut(&mut lending_market.reserves, deposit_reserve_id);
         let expected_ctokens = {
-            let deposit_reserve = vector::borrow(&lending_market.reserves, deposit_reserve_id);
             assert!(reserve::coin_type(deposit_reserve) == type_name::get<RewardType>(), EWrongType);
 
             floor(
@@ -706,12 +720,7 @@ module suilend::lending_market {
         };
 
         if (expected_ctokens == 0) {
-            if (coin::value(&rewards) > 0) {
-                transfer::public_transfer(rewards, FEE_RECEIVER_DAO);
-            }
-            else {
-                coin::destroy_zero(rewards);
-            };
+            reserve::join_fees<P, RewardType>(deposit_reserve, coin::into_balance(rewards));
         }
         else {
             let ctokens = deposit_liquidity_and_mint_ctokens<P, RewardType>(
@@ -1047,6 +1056,34 @@ module suilend::lending_market {
         lending_market.rate_limiter = rate_limiter::new(config, clock::timestamp_ms(clock) / 1000);
     }
 
+    public fun set_fee_receivers<P>(
+        _: &LendingMarketOwnerCap<P>,
+        lending_market: &mut LendingMarket<P>,
+        receivers: vector<address>,
+        weights: vector<u64>,
+    ) {
+        assert!(lending_market.version == CURRENT_VERSION, EIncorrectVersion);
+
+        assert!(vector::length(&receivers) == vector::length(&weights), EInvalidFeeReceivers);
+        assert!(vector::length(&receivers) > 0, EInvalidFeeReceivers);
+
+        let total_weight = vector::fold!(weights, 0, |acc, weight| acc + weight);
+        assert!(total_weight > 0, EInvalidFeeReceivers);
+
+        if (dynamic_field::exists_(&lending_market.id, FeeReceiversKey {})) {
+            let FeeReceivers { .. } = dynamic_field::remove<FeeReceiversKey, FeeReceivers>(
+                &mut lending_market.id, 
+                FeeReceiversKey {}
+            );
+        };
+
+        dynamic_field::add(
+            &mut lending_market.id, 
+            FeeReceiversKey {}, 
+            FeeReceivers { receivers, weights, total_weight }
+        );
+    }
+
     entry fun claim_fees<P, T>(
         lending_market: &mut LendingMarket<P>,
         reserve_array_index: u64,
@@ -1056,19 +1093,36 @@ module suilend::lending_market {
 
         let reserve = vector::borrow_mut(&mut lending_market.reserves, reserve_array_index);
         assert!(reserve::coin_type(reserve) == type_name::get<T>(), EWrongType);
+
         let (mut ctoken_fees, mut fees) = reserve::claim_fees<P, T>(reserve);
+        let total_ctoken_fees = balance::value(&ctoken_fees);
+        let total_fees = balance::value(&fees);
 
-        let dao_fee_amount = fees.value() * DAO_FEE_TAKE_RATE_PCT / 100;
-        let dao_fees = fees.split(dao_fee_amount);
+        let fee_receivers: &FeeReceivers = dynamic_field::borrow(&lending_market.id, FeeReceiversKey {});
+        let num_fee_receivers = vector::length(&fee_receivers.weights);
 
-        transfer::public_transfer(coin::from_balance(dao_fees, ctx), FEE_RECEIVER_DAO);
-        transfer::public_transfer(coin::from_balance(fees, ctx), FEE_RECEIVER_LABS);
+        num_fee_receivers.do!(|i| {
+            let fee_amount = total_fees * fee_receivers.weights[i] / fee_receivers.total_weight;
+            let fee = if (i == num_fee_receivers - 1) {
+                balance::withdraw_all(&mut fees)
+            } else {
+                balance::split(&mut fees, fee_amount)
+            };
 
-        let dao_ctoken_fee_amount = ctoken_fees.value() * DAO_FEE_TAKE_RATE_PCT / 100;
-        let dao_ctoken_fees = ctoken_fees.split(dao_ctoken_fee_amount);
+            transfer::public_transfer(coin::from_balance(fee, ctx), fee_receivers.receivers[i]);
 
-        transfer::public_transfer(coin::from_balance(dao_ctoken_fees, ctx), FEE_RECEIVER_DAO);
-        transfer::public_transfer(coin::from_balance(ctoken_fees, ctx), FEE_RECEIVER_LABS);
+            let ctoken_fee_amount = total_ctoken_fees * fee_receivers.weights[i] / fee_receivers.total_weight;
+            let ctoken_fee = if (i == num_fee_receivers - 1) {
+                balance::withdraw_all(&mut ctoken_fees)
+            } else {
+                balance::split(&mut ctoken_fees, ctoken_fee_amount)
+            };
+
+            transfer::public_transfer(coin::from_balance(ctoken_fee, ctx), fee_receivers.receivers[i]); 
+        });
+
+        balance::destroy_zero(fees);
+        balance::destroy_zero(ctoken_fees);
     }
 
     public fun new_obligation_owner_cap<P>(

--- a/contracts/suilend/sources/lending_market.move
+++ b/contracts/suilend/sources/lending_market.move
@@ -706,7 +706,12 @@ module suilend::lending_market {
         };
 
         if (expected_ctokens == 0) {
-            transfer::public_transfer(rewards, lending_market.fee_receiver);
+            if (coin::value(&rewards) > 0) {
+                transfer::public_transfer(rewards, FEE_RECEIVER_DAO);
+            }
+            else {
+                coin::destroy_zero(rewards);
+            };
         }
         else {
             let ctokens = deposit_liquidity_and_mint_ctokens<P, RewardType>(

--- a/contracts/suilend/sources/lending_market.move
+++ b/contracts/suilend/sources/lending_market.move
@@ -1102,23 +1102,31 @@ module suilend::lending_market {
         let num_fee_receivers = vector::length(&fee_receivers.weights);
 
         num_fee_receivers.do!(|i| {
-            let fee_amount = total_fees * fee_receivers.weights[i] / fee_receivers.total_weight;
+            let fee_amount = (total_fees as u128) * (fee_receivers.weights[i] as u128) / (fee_receivers.total_weight as u128);
             let fee = if (i == num_fee_receivers - 1) {
                 balance::withdraw_all(&mut fees)
             } else {
-                balance::split(&mut fees, fee_amount)
+                balance::split(&mut fees, fee_amount as u64)
             };
 
-            transfer::public_transfer(coin::from_balance(fee, ctx), fee_receivers.receivers[i]);
+            if (balance::value(&fee) > 0) {
+                transfer::public_transfer(coin::from_balance(fee, ctx), fee_receivers.receivers[i]);
+            } else {
+                balance::destroy_zero(fee);
+            };
 
-            let ctoken_fee_amount = total_ctoken_fees * fee_receivers.weights[i] / fee_receivers.total_weight;
+            let ctoken_fee_amount = (total_ctoken_fees as u128) * (fee_receivers.weights[i] as u128) / (fee_receivers.total_weight as u128);
             let ctoken_fee = if (i == num_fee_receivers - 1) {
                 balance::withdraw_all(&mut ctoken_fees)
             } else {
-                balance::split(&mut ctoken_fees, ctoken_fee_amount)
+                balance::split(&mut ctoken_fees, ctoken_fee_amount as u64)
             };
 
-            transfer::public_transfer(coin::from_balance(ctoken_fee, ctx), fee_receivers.receivers[i]); 
+            if (balance::value(&ctoken_fee) > 0) {
+                transfer::public_transfer(coin::from_balance(ctoken_fee, ctx), fee_receivers.receivers[i]); 
+            } else {
+                balance::destroy_zero(ctoken_fee);
+            };
         });
 
         balance::destroy_zero(fees);

--- a/contracts/suilend/sources/lending_market.move
+++ b/contracts/suilend/sources/lending_market.move
@@ -36,7 +36,7 @@ module suilend::lending_market {
     const EInvalidFeeReceivers: u64 = 8;
 
     // === Constants ===
-    const CURRENT_VERSION: u64 = 6;
+    const CURRENT_VERSION: u64 = 7;
     const U64_MAX: u64 = 18_446_744_073_709_551_615;
 
     // === One time Witness ===

--- a/contracts/suilend/sources/lending_market.move
+++ b/contracts/suilend/sources/lending_market.move
@@ -37,6 +37,10 @@ module suilend::lending_market {
     const CURRENT_VERSION: u64 = 6;
     const U64_MAX: u64 = 18_446_744_073_709_551_615;
 
+    const FEE_RECEIVER_DAO: address = @0xd52680ae4a2fc9920cd9b102203ea4ee5334fc36bdac0ebd111fdc8f42069129;
+    const FEE_RECEIVER_LABS: address = @0x7d68adb758c18d0f1e6cbbfe07c4c12bce92de37ce61b27b51245a568381b83e;
+    const DAO_FEE_TAKE_RATE_PCT: u64 = 70;
+
     // === One time Witness ===
     public struct LENDING_MARKET has drop {}
 
@@ -1047,10 +1051,19 @@ module suilend::lending_market {
 
         let reserve = vector::borrow_mut(&mut lending_market.reserves, reserve_array_index);
         assert!(reserve::coin_type(reserve) == type_name::get<T>(), EWrongType);
-        let (ctoken_fees, fees) = reserve::claim_fees<P, T>(reserve);
+        let (mut ctoken_fees, mut fees) = reserve::claim_fees<P, T>(reserve);
 
-        transfer::public_transfer(coin::from_balance(ctoken_fees, ctx), lending_market.fee_receiver);
-        transfer::public_transfer(coin::from_balance(fees, ctx), lending_market.fee_receiver);
+        let dao_fee_amount = fees.value() * DAO_FEE_TAKE_RATE_PCT / 100;
+        let dao_fees = fees.split(dao_fee_amount);
+
+        transfer::public_transfer(coin::from_balance(dao_fees, ctx), FEE_RECEIVER_DAO);
+        transfer::public_transfer(coin::from_balance(fees, ctx), FEE_RECEIVER_LABS);
+
+        let dao_ctoken_fee_amount = ctoken_fees.value() * DAO_FEE_TAKE_RATE_PCT / 100;
+        let dao_ctoken_fees = ctoken_fees.split(dao_ctoken_fee_amount);
+
+        transfer::public_transfer(coin::from_balance(dao_ctoken_fees, ctx), FEE_RECEIVER_DAO);
+        transfer::public_transfer(coin::from_balance(ctoken_fees, ctx), FEE_RECEIVER_LABS);
     }
 
     public fun new_obligation_owner_cap<P>(

--- a/contracts/suilend/sources/reserve.move
+++ b/contracts/suilend/sources/reserve.move
@@ -915,7 +915,7 @@ module suilend::reserve {
     }
 
     // === Private Functions ===
-    fun log_reserve_data<P>(reserve: &Reserve<P>){
+    fun log_reserve_data<P>(reserve: &Reserve<P>) {
         let available_amount_decimal = decimal::from(reserve.available_amount);
         let supply_amount = total_supply(reserve);
         let cur_util = calculate_utilization_rate(reserve);

--- a/contracts/suilend/sources/reserve.move
+++ b/contracts/suilend/sources/reserve.move
@@ -535,6 +535,11 @@ module suilend::reserve {
         (protocol_fee_amount, liquidator_bonus_amount)
     }
 
+    public(package) fun join_fees<P, T>(reserve: &mut Reserve<P>, fees: Balance<T>) {
+        let balances: &mut Balances<P, T> = dynamic_field::borrow_mut(&mut reserve.id, BalanceKey {});
+        balance::join(&mut balances.fees, fees);
+    }
+
     public(package) fun update_reserve_config<P>(
         reserve: &mut Reserve<P>, 
         config: ReserveConfig, 

--- a/contracts/suilend/tests/lending_market_tests.move
+++ b/contracts/suilend/tests/lending_market_tests.move
@@ -32,6 +32,9 @@ module suilend::lending_market_tests {
     const U64_MAX: u64 = 18446744073709551615;
     const MIST_PER_SUI: u64 = 1_000_000_000;
 
+    const FEE_RECEIVER_DAO: address = @0xd52680ae4a2fc9920cd9b102203ea4ee5334fc36bdac0ebd111fdc8f42069129;
+    const FEE_RECEIVER_LABS: address = @0x7d68adb758c18d0f1e6cbbfe07c4c12bce92de37ce61b27b51245a568381b83e;
+
     #[test]
     fun test_create_lending_market() {
         use sui::test_scenario::{Self};
@@ -548,10 +551,14 @@ module suilend::lending_market_tests {
 
         test_scenario::next_tx(&mut scenario, owner);
 
-        let fees: Coin<TEST_SUI> = test_scenario::take_from_address(&scenario, lending_market::fee_receiver(&lending_market));
-        assert!(coin::value(&fees) == 1_000_000, 0);
+        let fees_dao: Coin<TEST_SUI> = test_scenario::take_from_address(&scenario, FEE_RECEIVER_DAO);
+        let fees_labs: Coin<TEST_SUI> = test_scenario::take_from_address(&scenario, FEE_RECEIVER_LABS);
 
-        test_utils::destroy(fees);
+        assert!(coin::value(&fees_dao) == 700_000, 0);
+        assert!(coin::value(&fees_labs) == 300_000, 0);
+
+        test_utils::destroy(fees_dao);
+        test_utils::destroy(fees_labs);
 
         test_utils::destroy(sui);
         test_utils::destroy(obligation_owner_cap);
@@ -868,13 +875,22 @@ module suilend::lending_market_tests {
         );
 
         test_scenario::next_tx(&mut scenario, owner);
-        let ctoken_fees: Coin<CToken<LENDING_MARKET, TEST_USDC>> = test_scenario::take_from_address(
+        let ctoken_fees_dao: Coin<CToken<LENDING_MARKET, TEST_USDC>> = test_scenario::take_from_address(
             &scenario, 
-            lending_market::fee_receiver(&lending_market)
+            FEE_RECEIVER_DAO
         );
-        assert!(coin::value(&ctoken_fees) == 600_000, 0);
 
-        test_utils::destroy(ctoken_fees);
+        let ctoken_fees_labs: Coin<CToken<LENDING_MARKET, TEST_USDC>> = test_scenario::take_from_address(
+            &scenario, 
+            FEE_RECEIVER_LABS
+        );
+
+        assert!(coin::value(&ctoken_fees_dao) + coin::value(&ctoken_fees_labs) == 600_000, 0);
+        assert!(coin::value(&ctoken_fees_dao) == 420_000, 0); // 600_000 * 70%
+        assert!(coin::value(&ctoken_fees_labs) == 180_000, 0);
+
+        test_utils::destroy(ctoken_fees_dao);
+        test_utils::destroy(ctoken_fees_labs);
         test_utils::destroy(sui);
         test_utils::destroy(tokens);
         test_utils::destroy(obligation_owner_cap);
@@ -2027,10 +2043,14 @@ module suilend::lending_market_tests {
 
         test_scenario::next_tx(&mut scenario, owner);
 
-        let fees: Coin<SUI> = test_scenario::take_from_address(&scenario, lending_market::fee_receiver(&lending_market));
-        assert!(coin::value(&fees) == 49 * MIST_PER_SUI, 0);
+        let fees_dao: Coin<SUI> = test_scenario::take_from_address(&scenario, FEE_RECEIVER_DAO);
+        let fees_labs: Coin<SUI> = test_scenario::take_from_address(&scenario, FEE_RECEIVER_LABS);
 
-        test_utils::destroy(fees);
+        assert!(coin::value(&fees_dao) == 34 * MIST_PER_SUI + 300_000_000, 0);
+        assert!(coin::value(&fees_labs) == 14 * MIST_PER_SUI + 700_000_000, 0);
+
+        test_utils::destroy(fees_dao);
+        test_utils::destroy(fees_labs);
 
         test_utils::destroy(owner_cap);
         test_utils::destroy(lending_market);

--- a/contracts/suilend/tests/lending_market_tests.move
+++ b/contracts/suilend/tests/lending_market_tests.move
@@ -540,6 +540,13 @@ module suilend::lending_market_tests {
 
         test_scenario::next_tx(&mut scenario, owner);
 
+        lending_market::set_fee_receivers<LENDING_MARKET>(
+            &owner_cap,
+            &mut lending_market,
+            vector[tx_context::sender(test_scenario::ctx(&mut scenario)), @0x27],
+            vector[1, 2]
+        );
+
         lending_market::claim_fees<LENDING_MARKET, TEST_SUI>(
             &mut lending_market,
             *bag::borrow(&type_to_index, type_name::get<TEST_SUI>()),
@@ -548,9 +555,12 @@ module suilend::lending_market_tests {
 
         test_scenario::next_tx(&mut scenario, owner);
 
-        let fees: Coin<TEST_SUI> = test_scenario::take_from_address(&scenario, lending_market::fee_receiver(&lending_market));
-        assert!(coin::value(&fees) == 1_000_000, 0);
+        let fees: Coin<TEST_SUI> = test_scenario::take_from_address(&scenario, @0x26);
+        assert!(coin::value(&fees) == 1_000_000 / 3, 0);
+        test_utils::destroy(fees);
 
+        let fees: Coin<TEST_SUI> = test_scenario::take_from_address(&scenario, @0x27);
+        assert!(coin::value(&fees) == 2 * 1_000_000 / 3 + 1, 0);
         test_utils::destroy(fees);
 
         test_utils::destroy(sui);

--- a/contracts/suilend/tests/lending_market_tests.move
+++ b/contracts/suilend/tests/lending_market_tests.move
@@ -32,9 +32,6 @@ module suilend::lending_market_tests {
     const U64_MAX: u64 = 18446744073709551615;
     const MIST_PER_SUI: u64 = 1_000_000_000;
 
-    const FEE_RECEIVER_DAO: address = @0xd52680ae4a2fc9920cd9b102203ea4ee5334fc36bdac0ebd111fdc8f42069129;
-    const FEE_RECEIVER_LABS: address = @0x7d68adb758c18d0f1e6cbbfe07c4c12bce92de37ce61b27b51245a568381b83e;
-
     #[test]
     fun test_create_lending_market() {
         use sui::test_scenario::{Self};
@@ -551,14 +548,10 @@ module suilend::lending_market_tests {
 
         test_scenario::next_tx(&mut scenario, owner);
 
-        let fees_dao: Coin<TEST_SUI> = test_scenario::take_from_address(&scenario, FEE_RECEIVER_DAO);
-        let fees_labs: Coin<TEST_SUI> = test_scenario::take_from_address(&scenario, FEE_RECEIVER_LABS);
+        let fees: Coin<TEST_SUI> = test_scenario::take_from_address(&scenario, lending_market::fee_receiver(&lending_market));
+        assert!(coin::value(&fees) == 1_000_000, 0);
 
-        assert!(coin::value(&fees_dao) == 700_000, 0);
-        assert!(coin::value(&fees_labs) == 300_000, 0);
-
-        test_utils::destroy(fees_dao);
-        test_utils::destroy(fees_labs);
+        test_utils::destroy(fees);
 
         test_utils::destroy(sui);
         test_utils::destroy(obligation_owner_cap);
@@ -875,22 +868,13 @@ module suilend::lending_market_tests {
         );
 
         test_scenario::next_tx(&mut scenario, owner);
-        let ctoken_fees_dao: Coin<CToken<LENDING_MARKET, TEST_USDC>> = test_scenario::take_from_address(
+        let ctoken_fees: Coin<CToken<LENDING_MARKET, TEST_USDC>> = test_scenario::take_from_address(
             &scenario, 
-            FEE_RECEIVER_DAO
+            lending_market::fee_receiver(&lending_market)
         );
+        assert!(coin::value(&ctoken_fees) == 600_000, 0);
 
-        let ctoken_fees_labs: Coin<CToken<LENDING_MARKET, TEST_USDC>> = test_scenario::take_from_address(
-            &scenario, 
-            FEE_RECEIVER_LABS
-        );
-
-        assert!(coin::value(&ctoken_fees_dao) + coin::value(&ctoken_fees_labs) == 600_000, 0);
-        assert!(coin::value(&ctoken_fees_dao) == 420_000, 0); // 600_000 * 70%
-        assert!(coin::value(&ctoken_fees_labs) == 180_000, 0);
-
-        test_utils::destroy(ctoken_fees_dao);
-        test_utils::destroy(ctoken_fees_labs);
+        test_utils::destroy(ctoken_fees);
         test_utils::destroy(sui);
         test_utils::destroy(tokens);
         test_utils::destroy(obligation_owner_cap);
@@ -2043,14 +2027,10 @@ module suilend::lending_market_tests {
 
         test_scenario::next_tx(&mut scenario, owner);
 
-        let fees_dao: Coin<SUI> = test_scenario::take_from_address(&scenario, FEE_RECEIVER_DAO);
-        let fees_labs: Coin<SUI> = test_scenario::take_from_address(&scenario, FEE_RECEIVER_LABS);
+        let fees: Coin<SUI> = test_scenario::take_from_address(&scenario, lending_market::fee_receiver(&lending_market));
+        assert!(coin::value(&fees) == 49 * MIST_PER_SUI, 0);
 
-        assert!(coin::value(&fees_dao) == 34 * MIST_PER_SUI + 300_000_000, 0);
-        assert!(coin::value(&fees_labs) == 14 * MIST_PER_SUI + 700_000_000, 0);
-
-        test_utils::destroy(fees_dao);
-        test_utils::destroy(fees_labs);
+        test_utils::destroy(fees);
 
         test_utils::destroy(owner_cap);
         test_utils::destroy(lending_market);


### PR DESCRIPTION
- allow admin to specify a variable number of fee receivers and weights
- don't send dust to fee receiver in `claim_rewards_and_deposit`. join the dust to the fee balance instead