### PR TITLE
feat: Add Query Functions to Help Get Earned Rewards

### DIFF
--- a/contracts/suilend/Move.lock
+++ b/contracts/suilend/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "6781C6A6706E7547FDDE140BD7880B44DD07AF42D5F3EDB94B61E8433A04AF59"
+manifest_digest = "3AF8323D05FAD075BC83B729096C3890F027FCED65A3575C2407AB3FAD678702"
 deps_digest = "CAFAD8A7CF51067FB4358215BECB86BD100DD64E57C2AC8A7AE7D74B688F5965"
 dependencies = [
   { id = "Bridge", name = "Bridge" },
@@ -16,7 +16,7 @@ dependencies = [
 
 [[move.package]]
 id = "Bridge"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "3802482bd4e3", subdir = "crates/sui-framework/packages/bridge" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "b5633abb4177", subdir = "crates/sui-framework/packages/bridge" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -26,7 +26,7 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "3802482bd4e3", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "b5633abb4177", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Pyth"
@@ -39,7 +39,7 @@ dependencies = [
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "3802482bd4e3", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "b5633abb4177", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -47,7 +47,7 @@ dependencies = [
 
 [[move.package]]
 id = "SuiSystem"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "3802482bd4e3", subdir = "crates/sui-framework/packages/sui-system" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "b5633abb4177", subdir = "crates/sui-framework/packages/sui-system" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -83,6 +83,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.48.4"
+compiler-version = "1.49.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/suilend/sources/liquidity_mining.move
+++ b/contracts/suilend/sources/liquidity_mining.move
@@ -65,6 +65,44 @@ module suilend::liquidity_mining {
         user_reward_manager.share
     }
 
+    /// === Start ===
+    /// New functions added to support obligation-based reward tracking
+    /// These functions enable tracking and claiming of rewards based on user obligations
+    /// by providing access to user's reward information and pending rewards amount
+    public fun rewards(
+        user_reward_manager: &UserRewardManager
+    ): &vector<Option<UserReward>>{
+        &user_reward_manager.rewards
+    }
+
+    public fun user_reward(
+        user_rewards: &vector<Option<UserReward>>,
+        reward_index: u64,
+    ): &Option<UserReward>{
+        user_rewards.borrow(reward_index)
+    }
+
+    public fun earned_rewards(
+        user_reward: &UserReward,
+    ): Decimal{
+        user_reward.earned_rewards
+    }
+
+    public fun cumulative_rewards_per_share(
+        user_reward: &UserReward,
+    ): Decimal{
+        user_reward.cumulative_rewards_per_share
+    }
+
+    public use fun user_reward_pool_reward_id as UserReward.pool_reward_id;
+    public fun user_reward_pool_reward_id(
+        user_reward: &UserReward,
+    ):ID{
+        user_reward.pool_reward_id
+    }
+
+    // ==== End ====
+
     public fun last_update_time_ms(user_reward_manager: &UserRewardManager): u64 {
         user_reward_manager.last_update_time_ms
     }

--- a/contracts/suilend/sources/liquidity_mining.move
+++ b/contracts/suilend/sources/liquidity_mining.move
@@ -112,6 +112,11 @@ module suilend::liquidity_mining {
         let pool_reward = option::borrow(optional_pool_reward);
         object::id(pool_reward)
     }
+    public fun pool_rewards(
+        pool_reward_manager: &PoolRewardManager, 
+    ): &vector<Option<PoolReward>>{
+        &pool_reward_manager.pool_rewards
+    }
 
     public fun pool_reward(
         pool_reward_manager: &PoolRewardManager,


### PR DESCRIPTION
I integrated the Suilend contract and created an object to hold the **ObligationOwnerCap** from Suilend. However, I encountered a challenge: I cannot retrieve information about user earned rewards directly from the contract. To address this, I am submitting this PR to add query functions that allow users to obtain earned rewards from **UserRewardManager** without claiming them.

If you have any suggestions or feedback, please let me know. I hope this PR can be merged, or alternatively, I would appreciate any other solutions to help resolve this issue.